### PR TITLE
Use final message as a key in duplication filter

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,1 +1,2 @@
 * danilo shiga <danilo.shiga@olist.com>
+* rodrigo araujo <rodrigo.araujo@olist.com>

--- a/belogging/filters.py
+++ b/belogging/filters.py
@@ -55,15 +55,16 @@ class LoggerDuplicationFilter(logging.Filter):
 
     def filter(self, record):
         with self.lock:
-            if record.msg in self._cache:
+            msg = record.getMessage()
+            if msg in self._cache:
                 now = datetime.utcnow()
-                delta = now - self._cache[record.msg]['time']
+                delta = now - self._cache[msg]['time']
                 if delta.seconds >= self._cache_expire:
-                    self._cache[record.msg]['time'] = now
-                    self._cache[record.msg]['hits'] = 10
+                    self._cache[msg]['time'] = now
+                    self._cache[msg]['hits'] = 10
                     return True
 
-                self._cache[record.msg]['hits'] += 1
+                self._cache[msg]['hits'] += 1
                 return False
 
         if len(self._cache) >= self._cache_size:
@@ -73,5 +74,5 @@ class LoggerDuplicationFilter(logging.Filter):
                 self._cache.pop(key, None)
 
         with self.lock:
-            self._cache[record.msg] = {'time': datetime.utcnow(), 'hits': 0}
+            self._cache[msg] = {'time': datetime.utcnow(), 'hits': 0}
         return True

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -81,6 +81,10 @@ def test_default_duplication_filter():
     assert ft.filter(create_record(msg='repeated')) is True
     assert ft.filter(create_record(msg='repeated')) is False
     assert ft.filter(create_record(msg='not repeated')) is True
+
+
+def test_message_template_duplication_filter():
+    ft = LoggerDuplicationFilter()
     assert ft.filter(create_record(msg='template %s', args=['teste'])) is True
     assert ft.filter(create_record(msg='template %s', args=['teste'])) is False
     assert ft.filter(create_record(msg='template %s', args=['teste2'])) is True

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -8,9 +8,9 @@ from belogging.exceptions import ConfigurationWarning
 from belogging.filters import LoggerFilter, LoggerDuplicationFilter
 
 
-def create_record(name='test_logger', level='DEBUG', msg='foobar'):
+def create_record(name='test_logger', level='DEBUG', msg='foobar', args=None):
     return LogRecord(name=name, level=LEVEL_MAP[level], msg=msg, lineno=None,
-                     args=None, exc_info=None, pathname=None)
+                     args=args, exc_info=None, pathname=None)
 
 # LoggerFilter
 
@@ -81,6 +81,9 @@ def test_default_duplication_filter():
     assert ft.filter(create_record(msg='repeated')) is True
     assert ft.filter(create_record(msg='repeated')) is False
     assert ft.filter(create_record(msg='not repeated')) is True
+    assert ft.filter(create_record(msg='template %s', args=['teste'])) is True
+    assert ft.filter(create_record(msg='template %s', args=['teste'])) is False
+    assert ft.filter(create_record(msg='template %s', args=['teste2'])) is True
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Currently, belogging uses the message as a key in duplication's filter cache. There is a problem when we use the message as a template:

```python
logger.info(template_str, parameter1, parameter2, parameterN)
```

As the belogging uses template_str to detect duplicities, it sould consider the arguments of the log in order to avoid skipping logs when their parameters values are modified.

I pourpose that belogging uses the final message (record.getMessage) to solve this issue.

Consider belogging's duplication filter enabled:
```python
log.info('teste')
log.info('teste')
# it must log "teste" one time

log.info('teste %s',  'teste')
log.info('teste %s',  'teste')
# it must log "teste teste" one time

log.info('teste %s', 'value1')
log.info('teste %s', 'value2')
# it must log "teste value1" and "teste value2"
```

